### PR TITLE
feat: relax question_type check constraint

### DIFF
--- a/supabase/migrations/20250822171038_fix_question_type_constraint.sql
+++ b/supabase/migrations/20250822171038_fix_question_type_constraint.sql
@@ -1,0 +1,16 @@
+-- Fix the question_type check constraint to allow all the question types from the frontend
+ALTER TABLE public.questions DROP CONSTRAINT IF EXISTS questions_question_type_check;
+
+-- Add the correct check constraint with all supported question types
+ALTER TABLE public.questions ADD CONSTRAINT questions_question_type_check
+CHECK (question_type IN (
+  'multiple_choice',
+  'fill_blank',
+  'written',
+  'poll',
+  'true_false',
+  'complete',
+  'matching',
+  'translate',
+  'paragraph'
+));


### PR DESCRIPTION
Adds a new database migration to update the CHECK constraint on the `question_type` column in the `questions` table.

The previous constraint was too restrictive and caused errors when creating exams with newer question types from the frontend.

This migration drops the old constraint and adds a new one that includes all currently supported question types.